### PR TITLE
Add treatment for different data years

### DIFF
--- a/dataviva/api/attrs/services.py
+++ b/dataviva/api/attrs/services.py
@@ -60,6 +60,7 @@ class Location:
 
     def __init__(self, bra_id):
         self._attrs_list = None
+        self._attrs_list_dhs = None
         self._ybs_sorted_by_ranking = None
         self.bra_id = bra_id
         if len(bra_id) != 9 and len(bra_id) != 3:
@@ -73,9 +74,13 @@ class Location:
         else:
             self.max_year_query = db.session.query(
                 func.max(Ybs.year)).filter_by(bra_id=bra_id)
+            self.max_year_dhs = self.year_dhs()
             self.attrs_query = Ybs.query.filter(
                 Ybs.bra_id == self.bra_id,
                 Ybs.year == self.max_year_query)
+            self.attrs_query_dhs = Ybs.query.filter(
+                Ybs.bra_id == self.bra_id,
+                Ybs.year == self.max_year_dhs)
 
     def __ybs_sorted_by_ranking__(self):
         if not self._ybs_sorted_by_ranking:
@@ -99,6 +104,12 @@ class Location:
             self._attrs_list = attrs_data
         return self._attrs_list
 
+    def __attrs_list_dhs__(self):
+        if not self._attrs_list_dhs:
+            attrs_data = self.attrs_query_dhs.all()
+            self._attrs_list_dhs = attrs_data
+        return self._attrs_list_dhs
+
     def gdp(self):
         attrs = self.__attrs_list__()
         attr = next((attr for attr in attrs if attr.stat_id == 'gdp'),
@@ -106,13 +117,13 @@ class Location:
         return attr.stat_val
 
     def hdi(self):
-        attrs = self.__attrs_list__()
+        attrs = self.__attrs_list_dhs__()
         attr = next((attr for attr in attrs if attr.stat_id == 'hdi'),
                     None)
         return attr.stat_val
 
     def life_expectation(self):
-        attrs = self.__attrs_list__()
+        attrs = self.__attrs_list_dhs__()
         attr = next((attr for attr in attrs if attr.stat_id == 'life_exp'),
                     None)
         return attr.stat_val
@@ -135,6 +146,9 @@ class Location:
 
     def year(self):
         return self.max_year_query.first()[0]
+
+    def year_dhs(self):
+        return 2010
 
     def number_of_locations(self, bra_length):
         if bra_length == 1 or bra_length == 3:

--- a/dataviva/apps/location/templates/location/index.html
+++ b/dataviva/apps/location/templates/location/index.html
@@ -139,7 +139,7 @@
                     {% if header.life_expectation %}
                     <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
                         <div class="widget">
-                            <h2 class="text-left text-uppercase">{% trans %}Life Expectancy{% endtrans %} ({{header.year}})</h2>
+                            <h2 class="text-left text-uppercase">{% trans %}Life Expectancy{% endtrans %} ({{header.year_dhs}})</h2>
                             <div class="number">
                                 <strong class="counter">{{ header.life_expectation|max_digits(3, True) }}</strong><br/>
                                 <small class="magnitude">{% trans %}Years{% endtrans %}</small>
@@ -175,7 +175,7 @@
                     {% if header.hdi %}
                     <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
                         <div class="widget">
-                            <h2 class="text-left text-uppercase">{% trans %}MHDI{% endtrans %} ({{header.year}})</h2>
+                            <h2 class="text-left text-uppercase">{% trans %}MHDI{% endtrans %} ({{header.year_dhs}})</h2>
                             <div class="number">
                                 <strong class="counter">{{ header.hdi|max_digits(3, True) }}</strong><br/>
                                 <small class="magnitude">{{ header.hdi|magnitude }}</small>

--- a/dataviva/apps/location/views.py
+++ b/dataviva/apps/location/views.py
@@ -400,7 +400,8 @@ def index(bra_id, tab):
             'gdp_per_capita': location_service.gdp_per_capita(),
             'hdi': location_service.hdi(),
             'bg_class_image': background_image,
-            'year': location_service.year()
+            'year': location_service.year(),
+            'year_dhs': location_service.year_dhs()
         }
 
     if eci is not None:


### PR DESCRIPTION
Como os dados gerais de localidade só podem ser atualizados parcialmente, foi feito um tratamento para exibir os dados com diferença de anos.

@msbandrade modificações em ambiente de _staging_ para validação.

Paralelamente foi realizado a transformação e carregamentos dos dados para as tabelas usando o seguinte _script_:
https://github.com/DataViva/dataviva-etl/blob/master/static_tables/load/attrs_ybs_2016.sql